### PR TITLE
refine_assembly fix for empty reads input

### DIFF
--- a/assembly.py
+++ b/assembly.py
@@ -841,6 +841,10 @@ def refine_assembly(
 
     if already_realigned_bam:
         realignBam = already_realigned_bam
+        if samtools.isEmpty(realignBam):
+            # GATK errors out on empty bam input, so just do this ourselves
+            util.file.touch(outFasta)
+            return 0
     else:
         # Novoalign reads to self
         novoBam = util.file.mkstempfname('.novoalign.bam')

--- a/test/unit/test_assembly.py
+++ b/test/unit/test_assembly.py
@@ -17,6 +17,7 @@ import argparse
 import itertools
 import pytest
 import assemble.mummer
+import tools.minimap2
 import tools.novoalign
 import tools.picard
 from test import TestCaseWithTmp, _CPUS
@@ -63,6 +64,25 @@ class TestRefineAssemble(TestCaseWithTmp):
         self.assertTrue(os.path.isfile(outFasta))
         self.assertTrue(os.path.getsize(outFasta) == 0)
 
+    def test_aligned_empty_input_bam_assembly(self):
+        mm2 = tools.minimap2.Minimap2()
+        samtools = tools.samtools.SamtoolsTool()
+        with util.file.tempfname('.ref.fasta') as inFasta:
+            with util.file.tempfname('.bam') as inBam:
+                with util.file.tempfname('.refined.fasta') as outFasta:
+                    shutil.copyfile(os.path.join(util.file.get_test_input_path(), 'ebov-makona.fasta'), inFasta)
+                    mm2.align_bam(os.path.join(util.file.get_test_input_path(), 'empty.bam'), inFasta, inBam,
+                        options=['-x', 'sr'])
+                    samtools.index(inBam)
+
+                    # run refine_assembly
+                    args = [inFasta, inBam, outFasta, "--already_realigned_bam", inBam]
+                    args = assembly.parser_refine_assembly(argparse.ArgumentParser()).parse_args(args)
+                    args.func_main(args)
+
+                    # the expected output is an empty fasta file
+                    self.assertTrue(os.path.isfile(outFasta))
+                    self.assertTrue(os.path.getsize(outFasta) == 0)
 
     def test_empty_input_fasta_assembly(self):
         novoalign = tools.novoalign.NovoalignTool()


### PR DESCRIPTION
assemble.refine_assembly had been resilient to receiving empty reads (and empty reference) input, but not when `--already_realigned_bam` was specified (which is how our WDLs currently use this).

This PR:
 - adds a unit test for empty bam input to refine_assembly using `--already_realigned_bam` (initially failing)
 - adds a code path to handle this scenario properly
 - and now passes the new test