### PR TITLE
fix refine_assembly outVcf when no aligned reads

### DIFF
--- a/assembly.py
+++ b/assembly.py
@@ -825,7 +825,7 @@ def refine_assembly(
     if (os.path.getsize(inFasta) == 0):
         util.file.touch(outFasta)
         if outVcf:
-            with util.file.open_or_gzopen(outVcf, 'w') as outf:
+            with util.file.open_or_gzopen(outVcf, 'wt') as outf:
                 outf.write('##fileformat=VCFv4.3')
                 outf.write('\t'.join(('#CHROM','POS','ID','REF','ALT','QUAL','FILTER','INFO','FORMAT'))+'\n')
         return 0
@@ -849,7 +849,7 @@ def refine_assembly(
             # GATK errors out on empty bam input, so just do this ourselves
             util.file.touch(outFasta)
             if outVcf:
-                with util.file.open_or_gzopen(outVcf, 'w') as outf:
+                with util.file.open_or_gzopen(outVcf, 'wt') as outf:
                     outf.write('##fileformat=VCFv4.3')
                     outf.write('\t'.join(('#CHROM','POS','ID','REF','ALT','QUAL','FILTER','INFO','FORMAT'))+'\n')
             return 0

--- a/assembly.py
+++ b/assembly.py
@@ -824,6 +824,10 @@ def refine_assembly(
     # if the input fasta is empty, create an empty output fasta and return
     if (os.path.getsize(inFasta) == 0):
         util.file.touch(outFasta)
+        if outVcf:
+            with util.file.open_or_gzopen(outVcf, 'w') as outf:
+                outf.write('##fileformat=VCFv4.3')
+                outf.write('\t'.join(('#CHROM','POS','ID','REF','ALT','QUAL','FILTER','INFO','FORMAT'))+'\n')
         return 0
 
     # Get tools
@@ -844,6 +848,10 @@ def refine_assembly(
         if samtools.isEmpty(realignBam):
             # GATK errors out on empty bam input, so just do this ourselves
             util.file.touch(outFasta)
+            if outVcf:
+                with util.file.open_or_gzopen(outVcf, 'w') as outf:
+                    outf.write('##fileformat=VCFv4.3')
+                    outf.write('\t'.join(('#CHROM','POS','ID','REF','ALT','QUAL','FILTER','INFO','FORMAT'))+'\n')
             return 0
     else:
         # Novoalign reads to self

--- a/test/unit/test_assembly.py
+++ b/test/unit/test_assembly.py
@@ -70,19 +70,22 @@ class TestRefineAssemble(TestCaseWithTmp):
         with util.file.tempfname('.ref.fasta') as inFasta:
             with util.file.tempfname('.bam') as inBam:
                 with util.file.tempfname('.refined.fasta') as outFasta:
-                    shutil.copyfile(os.path.join(util.file.get_test_input_path(), 'ebov-makona.fasta'), inFasta)
-                    mm2.align_bam(os.path.join(util.file.get_test_input_path(), 'empty.bam'), inFasta, inBam,
-                        options=['-x', 'sr'])
-                    samtools.index(inBam)
+                    with util.file.tempfname('.vcf.gz') as outVcf:
+                        shutil.copyfile(os.path.join(util.file.get_test_input_path(), 'ebov-makona.fasta'), inFasta)
+                        mm2.align_bam(os.path.join(util.file.get_test_input_path(), 'empty.bam'), inFasta, inBam,
+                            options=['-x', 'sr'])
+                        samtools.index(inBam)
 
-                    # run refine_assembly
-                    args = [inFasta, inBam, outFasta, "--already_realigned_bam", inBam]
-                    args = assembly.parser_refine_assembly(argparse.ArgumentParser()).parse_args(args)
-                    args.func_main(args)
+                        # run refine_assembly
+                        args = [inFasta, inBam, outFasta, "--already_realigned_bam", inBam, '--outVcf', outVcf]
+                        args = assembly.parser_refine_assembly(argparse.ArgumentParser()).parse_args(args)
+                        args.func_main(args)
 
-                    # the expected output is an empty fasta file
-                    self.assertTrue(os.path.isfile(outFasta))
-                    self.assertTrue(os.path.getsize(outFasta) == 0)
+                        # the expected output is an empty fasta file
+                        self.assertTrue(os.path.isfile(outFasta))
+                        self.assertTrue(os.path.getsize(outFasta) == 0)
+                        self.assertTrue(os.path.isfile(outVcf))
+                        self.assertTrue(os.path.getsize(outVcf) > 0)
 
     def test_empty_input_fasta_assembly(self):
         novoalign = tools.novoalign.NovoalignTool()


### PR DESCRIPTION
Previously, calling `refine_assembly` on a bam with no aligned reads caused us to write an empty output file manually because GATK would fail in such scenarios. But we forgot to emit an "empty" VCF file as well (causing downstream bcftools invocations in the WDL to fail). And an "empty" VCF file is not actually empty (it has a header). This PR ensures the VCF is written properly in the empty data scenario, and adds to the unit test to cover this.