### PR TITLE
bump viral-core to 2.1.33

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/broadinstitute/viral-core:2.1.20
+FROM quay.io/broadinstitute/viral-core:2.1.33
 
 LABEL maintainer "viral-ngs@broadinstitute.org"
 


### PR DESCRIPTION
Bump docker baseimage from viral-core 2.1.20 to 2.1.33