### PR TITLE
rename test action in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
           mkdir -p $CACHE_DIR
           github_actions_ci/list-docker-tags.sh | tail -1 | tee $CACHE_DIR/old-docker-tag.txt
 
-  test_py36_in_docker:
+  test_in_docker:
     needs: build_docker
     runs-on: ubuntu-20.04
     env:


### PR DESCRIPTION
rename test action in CI to remove mention of py version since the action host python version is irrelevant, since the one used for testing is set in viral-core: https://github.com/broadinstitute/viral-core/blob/master/Dockerfile#L30