### PR TITLE
update docker base image to v2.2.3 of viral-core; Update conftest.py to account for breaking changes in the newer version of pytest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/broadinstitute/viral-core:2.2.1
+FROM quay.io/broadinstitute/viral-core:2.2.3
 
 LABEL maintainer "viral-ngs@broadinstitute.org"
 

--- a/conftest.py
+++ b/conftest.py
@@ -165,13 +165,13 @@ class FixtureReporter:
         if self.durations is None:
             return
 
-        writer = terminalreporter.writer
+        writer = terminalreporter
 
         slowest = sorted(self.stats.items(), key=operator.itemgetter(1), reverse=True)
         if not self.durations:
-            writer.sep("=", "slowest fixture durations")
+            writer.write_sep("=", "slowest fixture durations")
         else:
-            writer.sep("=", "slowest %s fixture durations" % self.durations)
+            writer.write_sep("=", "slowest %s fixture durations" % self.durations)
             slowest = slowest[:self.durations]
 
 


### PR DESCRIPTION
update docker base image to v2.2.3 of viral-core; Update conftest.py to account for breaking changes in the newer version of pytest