### PR TITLE
bump viral-core to 2.3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/broadinstitute/viral-core:2.3.4
+FROM quay.io/broadinstitute/viral-core:2.3.5
 
 LABEL maintainer "viral-ngs@broadinstitute.org"
 


### PR DESCRIPTION
includes upstream bugfixes for fasta indexing by samtools when headers contain spaces