### PR TITLE
Skani scoring coverage may bias for large de novo

### DIFF
--- a/assemble/skani.py
+++ b/assemble/skani.py
@@ -81,7 +81,7 @@ class SkaniTool(tools.Tool):
         '''
         with open(in_tsv, 'r') as inf:
             reader = csv.DictReader(inf, delimiter='\t')
-            sorted_rows = sorted(reader, key=lambda row: float(row['ANI']) * float(row['Total_bases_covered']), reverse=True)
+            sorted_rows = sorted(reader, key=lambda row: float(row['ANI']) * float(row['Align_fraction_ref']), reverse=True)
 
         with open(out_tsv, 'w') as outf:
             writer = csv.DictWriter(outf, fieldnames=reader.fieldnames, delimiter='\t', dialect=csv.unix_dialect, quoting=csv.QUOTE_MINIMAL)


### PR DESCRIPTION
The `Total_bases_covered` field in Skani output refers to the query's coverage of the reference genome, which we noted led to an 86% ANI hit being selected over a 98% because there was greater than 100% coverage of the lower ANI hit, perhaps due to duplicate content in the de novo assembly. In other words, arbitrarily large de novo assemblies may bias Skani scoring. This may not be a problem in the context of this pipeline because of the smaller Skani dataset you're using, as well as the more reference-guided de novo assembly process.

We concluded it is preferable to use the `Align_fraction_ref` column in scoring instead of `Total_bases_covered`, which references the `Align_fraction_query` line. 