### PR TITLE
Fix sequip version mismatch causing missing Perl modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,9 @@ ENV VIRAL_ASSEMBLE_PATH=$INSTALL_PATH/viral-assemble
 COPY requirements-conda.txt $VIRAL_ASSEMBLE_PATH/
 RUN $VIRAL_NGS_PATH/docker/install-conda-dependencies.sh $VIRAL_ASSEMBLE_PATH/requirements-conda.txt $VIRAL_NGS_PATH/requirements-conda.txt
 
-# workaround
-ENV PERL5LIB=$PERL5LIB:/opt/miniconda/envs/viral-ngs-env/share/sequip-0.10/lib
+# workaround: add sequip lib directory to PERL5LIB
+# NOTE: sequip version here must match the version in requirements-conda.txt
+ENV PERL5LIB=$PERL5LIB:/opt/miniconda/envs/viral-ngs-env/share/sequip-0.11/lib
 
 # Copy all source code into the base repo
 # (this probably changes all the time, so all downstream build

--- a/requirements-conda.txt
+++ b/requirements-conda.txt
@@ -14,5 +14,5 @@ skani>=0.3.0
 #kwip>=0.2.0 ## relies on khmer, which as of 2024-03-12 does not support python 3.10
 # Perl packages below
 perl-bio-easel
-sequip
+sequip=0.11  ## version must match PERL5LIB path in Dockerfile
 # Python packages below


### PR DESCRIPTION
## Summary

Closes #58 - The `fasta-trim-terminal-ambigs.pl` script was failing in Docker images version 2.4.2.0+ due to missing Perl modules (`sqp_seq.pm` and `sqp_utils.pm`).

## Root Cause

The Dockerfile had a hardcoded path to `sequip-0.10/lib` but the conda package had been updated to version `0.11`, causing the PERL5LIB environment variable to point to a non-existent directory.

## Changes

### 1. Added Unit Test Coverage (`test/unit/test_assembly.py`)
- **`TestFastaTrimTerminalAmbigs.test_script_runs_successfully`**: Tests basic trimming of terminal ambiguous bases
- **`TestFastaTrimTerminalAmbigs.test_script_with_3rules_option`**: Tests the --3rules option using ebov-makona.fasta

### 2. Fixed Version Mismatch
- **`Dockerfile`**: Updated PERL5LIB to use `sequip-0.11/lib` instead of `sequip-0.10/lib`
- **`requirements-conda.txt`**: Pinned sequip to version `0.11`
- Added cross-referencing comments in both files to prevent future version mismatches

## Test Results

✅ **First commit** (e297f8ee): Tests failed as expected, confirming the bug
```
Can't locate sqp_seq.pm in @INC ... @INC contains: /opt/miniconda/envs/viral-ngs-env/share/sequip-0.10/lib
```

✅ **Second commit** (9a0369ba): All tests passed after fix
- ✓ build_docker (3m49s)
- ✓ test_docs (2m22s)  
- ✓ test_in_docker (3m12s)

## Affected Versions

- ✅ **Working**: viral-assemble 2.4.1.0 and earlier
- ❌ **Broken**: viral-assemble 2.4.2.0, 2.4.3.0
- ✅ **Fixed**: This PR

## Impact

This fixes all assembly workflows in viral-pipelines that use reference-based assembly refinement, including:
- `assemble_refbased.wdl`
- `assemble_denovo.wdl` (in the refinement step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>