### PR TITLE
Write header-only output when skani produces no matches

### DIFF
--- a/assemble/skani.py
+++ b/assemble/skani.py
@@ -20,6 +20,14 @@ TOOL_NAME = "skani"
 
 _log = logging.getLogger(__name__)
 
+# Standard output header for skani dist command
+SKANI_DIST_HEADER = ['Ref_file','Query_file','ANI','Align_fraction_ref','Align_fraction_query',
+                     'Ref_name','Query_name','Num_ref_contigs','Num_query_contigs',
+                     'ANI_5_percentile','ANI_95_percentile','Standard_deviation',
+                     'Ref_90_ctg_len','Ref_50_ctg_len','Ref_10_ctg_len',
+                     'Query_90_ctg_len','Query_50_ctg_len','Query_10_ctg_len',
+                     'Avg_chain_len','Total_bases_covered']
+
 class UndirectedGraph:
     ''' Simple utility class for finding clusters from pairwise relationships
     '''
@@ -84,9 +92,10 @@ class SkaniTool(tools.Tool):
             sorted_rows = sorted(reader, key=lambda row: float(row['ANI']) * float(row['Total_bases_covered']), reverse=True)
             fieldnames = reader.fieldnames  # Capture while file is still open
 
-        # Handle empty file case (no header, no data)
+        # Handle empty file case (no header, no data) - write header-only output
         if fieldnames is None:
-            open(out_tsv, 'w').close()
+            with open(out_tsv, 'w') as outf:
+                outf.write('\t'.join(SKANI_DIST_HEADER) + '\n')
             return
 
         with open(out_tsv, 'w') as outf:
@@ -120,7 +129,7 @@ class SkaniTool(tools.Tool):
         if self._is_fasta_basically_empty(query_fasta):
             _log.warning("Query fasta file is empty or contains only very short sequences. Skipping skani dist (which will fail in this scenario).")
             with open(outfile, 'w') as outf:
-                outf.write('\t'.join(['Ref_file','Query_file','ANI','Align_fraction_ref','Align_fraction_query','Ref_name','Query_name','Num_ref_contigs','Num_query_contigs','ANI_5_percentile','ANI_95_percentile','Standard_deviation','Ref_90_ctg_len','Ref_50_ctg_len','Ref_10_ctg_len','Query_90_ctg_len','Query_50_ctg_len','Query_10_ctg_len','Avg_chain_len','Total_bases_covered']) + '\n')
+                outf.write('\t'.join(SKANI_DIST_HEADER) + '\n')
         else:
             self.execute('dist', ['-q', query_fasta, '-r'] + list(ref_fastas) + list(other_args), outfile, threads=threads)
 

--- a/test/unit/test_assembly.py
+++ b/test/unit/test_assembly.py
@@ -721,9 +721,12 @@ class TestSkaniReferenceSelection(TestCaseWithTmp):
             # Should not raise exception
             skani._sort_skani_table_by_product(in_tsv, out_tsv)
 
-            # Output should exist and be empty
+            # Output should exist and have header only (not be empty)
             self.assertTrue(os.path.exists(out_tsv))
-            self.assertEqual(os.path.getsize(out_tsv), 0)
+            with open(out_tsv) as f:
+                lines = f.readlines()
+            self.assertEqual(len(lines), 1)
+            self.assertTrue(lines[0].startswith('Ref_file'))
 
     def test_sort_skani_table_header_only(self):
         """Test _sort_skani_table_by_product handles header-only input file"""


### PR DESCRIPTION
## Summary
- When skani dist finds no matches and produces an empty file (0 bytes), the downstream code in `skani_contigs_to_refs` fails because `readFlatFileHeader` returns `['']` for an empty file
- This causes the SIGPIPE (exit code 141) errors seen in Terra/Cromwell workflows
- The fix ensures that when the input file is empty, we write a proper header-only TSV file instead of an empty file
- Also refactors the skani dist header into a module-level constant (`SKANI_DIST_HEADER`) to avoid duplication

## Root cause
The previous fix in PR #63 correctly handled empty files in `_sort_skani_table_by_product`, but it created an empty (0 bytes) output file. When `readFlatFileHeader` reads an empty file:
1. `readline()` returns `''`
2. `''.split('\t')` returns `['']`
3. `csv.DictWriter(outf, [''], ...)` is created with a single empty-string fieldname
4. This causes downstream issues

## Test plan
- [x] `test_sort_skani_table_empty_file` - verifies empty input produces header-only output
- [x] `test_sort_skani_table_header_only` - verifies header-only input produces header-only output
- Both tests pass in Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)